### PR TITLE
renaming data  fields

### DIFF
--- a/examples/get_iss_data.py
+++ b/examples/get_iss_data.py
@@ -43,8 +43,8 @@ def load_and_write_data(input_dir, output_dir):
 
     res = dict()
     res['data'] = []
-    res['aux_data'] = []
-    res['meta_data'] = dict()
+    res['aux'] = []
+    res['metadata'] = dict()
 
     for h, hyb in enumerate(hyb_list):
         for c, img in enumerate(hyb):
@@ -58,11 +58,11 @@ def load_and_write_data(input_dir, output_dir):
 
     dapi_fname = '{}_{}.tiff'.format(prefix, 'dapi')
     imsave(output_dir + dapi_fname, dapi)
-    res['aux_data'].append({'type': 'dapi', 'file': dapi_fname})
+    res['aux'].append({'type': 'dapi', 'file': dapi_fname})
 
     dots_fname = '{}_{}.tiff'.format(prefix, 'dots')
     imsave(output_dir + dots_fname, dots)
-    res['aux_data'].append({'type': 'dots', 'file': dots_fname})
+    res['aux'].append({'type': 'dots', 'file': dots_fname})
 
     if len(img.shape) == 2:
         is_volume = False
@@ -71,11 +71,11 @@ def load_and_write_data(input_dir, output_dir):
     else:
         raise ValueError('Images must be 2D or 3D. Found: {}'.format(img.shape))
 
-    res['meta_data']['num_hybs'] = 4
-    res['meta_data']['num_chs'] = 4
-    res['meta_data']['shape'] = img.shape
-    res['meta_data']['is_volume'] = is_volume
-    res['meta_data']['format'] = 'tiff'
+    res['metadata']['num_hybs'] = 4
+    res['metadata']['num_chs'] = 4
+    res['metadata']['shape'] = img.shape
+    res['metadata']['is_volume'] = is_volume
+    res['metadata']['format'] = 'tiff'
 
     return res
 

--- a/starfish/io.py
+++ b/starfish/io.py
@@ -29,7 +29,7 @@ class Stack:
         self.squeeze_map = None
 
         # readers and writers
-        self.read_fn = None  # set by self._read_meta_data
+        self.read_fn = None  # set by self._read_metadata
         self.write_fn = np.save  # asserted for now
 
     @property
@@ -44,12 +44,12 @@ class Stack:
             self.org = json.load(in_file)
 
         self.path = os.path.dirname(os.path.abspath(in_json)) + '/'
-        self._read_meta_data()
+        self._read_metadata()
         self._read_stack()
         self._read_aux()
 
-    def _read_meta_data(self):
-        d = self.org['meta_data']
+    def _read_metadata(self):
+        d = self.org['metadata']
         self.num_hybs = d['num_hybs']
         self.num_chs = d['num_chs']
         self.im_shape = tuple(d['shape'])
@@ -78,7 +78,7 @@ class Stack:
             self.data[h, c, :] = im
 
     def _read_aux(self):
-        data_dicts = self.org['aux_data']
+        data_dicts = self.org['aux']
 
         for d in data_dicts:
             typ = d['type']
@@ -87,20 +87,20 @@ class Stack:
 
     # TODO should this thing write npy?
     def write(self, dir_name):
-        self._write_meta_data(dir_name)
+        self._write_metadata(dir_name)
         self._write_stack(dir_name)
         self._write_aux(dir_name)
 
-    def _write_meta_data(self, dir_name):
+    def _write_metadata(self, dir_name):
         new_org = self.org
-        new_org['meta_data']['format'] = 'npy'
+        new_org['metadata']['format'] = 'npy'
 
         def format(d):
             d['file'] = self._swap_ext(d['file']) + '.npy'
             return d
 
         new_org['data'] = [format(d) for d in new_org['data']]
-        new_org['aux_data'] = [format(d) for d in new_org['aux_data']]
+        new_org['aux'] = [format(d) for d in new_org['aux']]
 
         with open(os.path.join(dir_name, 'org.json'), 'w') as outfile:
             json.dump(new_org, outfile, indent=4)
@@ -115,7 +115,7 @@ class Stack:
             self.write_fn(os.path.join(dir_name, fname), self.data[h, c, :])
 
     def _write_aux(self, dir_name):
-        for d in self.org['aux_data']:
+        for d in self.org['aux']:
             typ = d['type']
             fname = d['file']
             self.write_fn(os.path.join(dir_name, fname), self.aux_dict[typ])
@@ -141,7 +141,7 @@ class Stack:
                                                                                           img.shape)
                 raise AttributeError(msg)
         else:
-            self.org['aux_data'].append({'file': key, 'type': key})
+            self.org['aux'].append({'file': key, 'type': key})
         self.aux_dict[key] = img
 
     def max_proj(self, dim):


### PR DESCRIPTION
Just some suggested renaming here:

`meta_data` -> `metadata` (this is a more common way to write it)
`aux_data` -> `aux` (possibly we'll have aux metadata)

So the fields are now `data`, `metadata`, and `aux`, which feels cleaner to me.

This change should only affect how we're writing the example data, and our `io` functions. 