### PR TITLE
geojson ouput

### DIFF
--- a/starfish/munge.py
+++ b/starfish/munge.py
@@ -37,6 +37,32 @@ def gather(df, key, value, cols):
     return pd.melt(df, id_vars, id_values, var_name, value_name)
 
 
+def spots_to_geojson(r):
+    '''
+    Convert spot geometrical data to geojson format
+    '''
+    def make_dict(row):
+        row = row[1]
+        d = dict()
+        d['properties'] = {'id':int(row.spot_id), 'radius': int(row.r)}
+        d['geometry'] = {'type':'Point', 'coordinates': [int(row.x), int(row.y)]}
+        return d
+    return [make_dict(row) for row in spots_viz.iterrows()]
+
+
+def regions_to_geojson(r):
+    '''
+    Convert region geometrical data to geojson format
+    '''
+    def make_dict(id, verts):
+        d = dict()
+        c = list(map(lambda x: list(x), list(map(lambda v: [int(v[0]), int(v[1])], verts))))
+        d["properties"] = {"id":id}
+        d["geometry"] = {"type":"Polygon", "coordinates": c}
+        return d
+    return [make_dict(id, verts) for id, verts in enumerate(r.hull)]
+
+
 def relabel(image):
     '''
     This is a local implementation of centrosome.cpmorphology.relabel

--- a/starfish/viz.py
+++ b/starfish/viz.py
@@ -19,35 +19,3 @@ def image_lims(im, num_std, bar=True, size=20):
     lim = stats['mean'] + num_std * stats['std']
     image(im, bar=bar, size=size, clim=[0, lim])
 
-
-def spots_geo_json(spots_viz_df, fname):
-    def make_spot_dict(row):
-        row = row[1]
-        d = dict()
-        d['properties'] = {'id': int(row.spot_id), 'radius': int(row.r)}
-        d['geometry'] = {'type': 'Point', 'coordinates': [int(row.x), int(row.y)]}
-        return d
-
-    spots_json = [make_spot_dict(row) for row in spots_viz_df.iterrows()]
-
-    with open(fname, 'wb') as outfile:
-        json.dump(spots_json, outfile)
-
-    return spots_json
-
-
-def regions_geo_json(region_labels, fname):
-    r = label_to_regions(region_labels)
-
-    def make_region_dict(id, verts):
-        d = dict()
-        d["properties"] = {"id": id}
-        d["geometry"] = {"type": "Polygon",
-                         "coordinates": list(map(lambda x: list(x), verts.astype(int)))
-                         }
-        return d
-
-    regions_json = [make_region_dict(id, verts) for id, verts in enumerate(r.hull)]
-
-    with open(fname, 'wb') as outfile:
-        json.dump(regions_json, outfile)


### PR DESCRIPTION
This PR adds support for converting `spot` and `region` information into the `geoJSON` format, and then exports to those formats in the CLI operations for `detect_spots` and `segment`. Munging functions derived from example Jupyter notebook. Confirmed that generated `regions.json` files could be used in web-based data visualization.