### PR TITLE
Add she-bang to the top of starfish.py

### DIFF
--- a/starfish/starfish.py
+++ b/starfish/starfish.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import os
 
 import click


### PR DESCRIPTION
This allows starfish to be run, rather than running python starfish.

Test:
```
[czipa1osx186 (.venv)]:~/microscopy/starfish:tonytung-env> pip install -e .
Obtaining file:///Users/ttung/microscopy/starfish
Installing collected packages: starfish
  Found existing installation: starfish 0.0.1
    Uninstalling starfish-0.0.1:
      Successfully uninstalled starfish-0.0.1
  Running setup.py develop for starfish
Successfully installed starfish
[czipa1osx186 (.venv)]:~/microscopy/starfish:tonytung-env> starfish
Usage: starfish [OPTIONS] COMMAND [ARGS]...

Options:
  --help  Show this message and exit.

Commands:
  decode
  detect_spots
  filter
  register
  segment
  show
[czipa1osx186 (.venv)]:~/microscopy/starfish:tonytung-env> 
```