### PR TITLE
Blacklist numpy 1.13.0

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,6 +1,6 @@
 click
 matplotlib
-numpy
+numpy != 1.13.0
 opencv-python
 pandas
 regional


### PR DESCRIPTION
Numpy 1.13.0 is the default numpy provided by travis's python 3.5 image.  This version is incompatible with starfish, so we need to blacklist it.

Here's an example log of it breaking: https://travis-ci.org/chanzuckerberg/starfish/jobs/293396599

```
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.5.3/bin/starfish", line 11, in <module>
    load_entry_point('starfish', 'console_scripts', 'starfish')()
  File "/home/travis/virtualenv/python3.5.3/lib/python3.5/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/travis/virtualenv/python3.5.3/lib/python3.5/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/travis/virtualenv/python3.5.3/lib/python3.5/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/virtualenv/python3.5.3/lib/python3.5/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/travis/virtualenv/python3.5.3/lib/python3.5/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/travis/build/chanzuckerberg/starfish/starfish/starfish.py", line 154, in segment
    cells_labels = seg.segment(dt, st, size_lim, disk_size_markers, disk_size_mask, md)
  File "/home/travis/build/chanzuckerberg/starfish/starfish/watershedsegmenter.py", line 30, in segment
    self.markers, self.num_cells = self.label_nuclei(min_allowed_size, max_allowed_size, min_dist)
  File "/home/travis/build/chanzuckerberg/starfish/starfish/watershedsegmenter.py", line 46, in label_nuclei
    markers, num_objs = self._unclump(min_dist)
  File "/home/travis/build/chanzuckerberg/starfish/starfish/watershedsegmenter.py", line 67, in _unclump
    local_maxi = peak_local_max(distance, labels=im, indices=False, min_distance=min_dist)
  File "/home/travis/virtualenv/python3.5.3/lib/python3.5/site-packages/skimage/feature/peak.py", line 127, in peak_local_max
    if np.any(np.diff(label_values) != 1):
  File "/home/travis/virtualenv/python3.5.3/lib/python3.5/site-packages/numpy/lib/function_base.py", line 1926, in diff
    return a[slice1]-a[slice2]
TypeError: numpy boolean subtract, the `-` operator, is deprecated, use the bitwise_xor, the `^` operator, or the logical_xor function instead.
```