### PR TITLE
Add coverage details in the integration test.

### DIFF
--- a/starfish/starfish.py
+++ b/starfish/starfish.py
@@ -195,3 +195,6 @@ def show(in_json, sz):
     s.read(in_json)
     tile(s.squeeze(), size=sz, bar=True)
     plt.show()
+
+if __name__ == "__main__":
+    starfish()

--- a/tests/test_iss_data.py
+++ b/tests/test_iss_data.py
@@ -83,6 +83,16 @@ class TestWithIssData(unittest.TestCase):
                     element(tempdir=tempdir) if callable(element) else element
                     for element in stage
                 ]
+                if cmdline[0] == 'starfish':
+                    coverage_cmdline = [
+                        "coverage", "run",
+                        "-p",
+                        "--source", "starfish",
+                        "-m", "starfish.starfish",
+                    ]
+                    coverage_cmdline.extend(cmdline[1:])
+                    cmdline = coverage_cmdline
+                    print(cmdline)
                 with clock.timeit(callback):
                     subprocess.check_call(cmdline)
         finally:


### PR DESCRIPTION
Run the subprocesses through coverage and merge the results at the end for code coverage details.