### PR TITLE
Added merfish-decoder

### DIFF
--- a/starfish/decoders/merfish.py
+++ b/starfish/decoders/merfish.py
@@ -1,0 +1,86 @@
+import numpy as np
+from skimage.measure import regionprops, label
+from sklearn.neighbors import NearestNeighbors
+import pandas as pd
+
+
+class MerfishDecoder:
+    def __init__(self, spots_df_tidy, codebook):
+        self.spots_df_tidy = spots_df_tidy
+        self.codebook = codebook
+
+        self.decoded_df = None
+
+    def decode(self,
+               img_size=(2048, 2048),
+               distance_threshold=0.5176,
+               magnitude_threshold=1,
+               area_threshold=2,
+               crop_size=40):
+
+        codes = self._parse_barcodes()
+        pixel_traces, pixel_traces_l2_norm = self._parse_pixel_traces()
+
+        nn = NearestNeighbors(n_neighbors=1, algorithm='ball_tree').fit(codes)
+        distances, indices = nn.kneighbors(pixel_traces)
+
+        # revert back to image space
+        decoded_img = np.reshape(indices + 1, img_size)
+        decoded_dist = np.reshape(distances, img_size)
+        local_magnitude = np.reshape(pixel_traces_l2_norm, img_size)
+
+        # find good 'spots'. filter out bad 'spots'
+        decoded_img[decoded_dist > distance_threshold] = 0
+        decoded_img[local_magnitude < magnitude_threshold] = 0
+        decoded_img = self._crop(decoded_img, crop_size)
+
+        decoded_df = self._find_spots(decoded_img, area_threshold)
+        decoded_df = pd.merge(decoded_df, self.codebook, on='barcode', how='left')
+        self.decoded_df = decoded_df
+        return self.decoded_df
+
+    def _parse_barcodes(self):
+        # parse barcode into numpy array and normalize by l2_norm
+        codes = np.array([np.array([int(d) for d in c]) for c in self.codebook.barcode])
+        codes_l2_norm = np.linalg.norm(codes, axis=1, ord=2)
+        weighted_codes = codes / codes_l2_norm[:, None]
+        return weighted_codes
+
+    def _parse_pixel_traces(self):
+        # parse spots into pixel traces, normalize and filter
+        df = self.spots_df_tidy.loc[:, ['spot_id', 'bit', 'val']]
+        # TODO this assumes that bits are sorted
+        pixel_traces = df.pivot(index='spot_id', columns='bit', values='val')
+        pixel_traces = pixel_traces.values
+        pixel_traces_l2_norm = np.linalg.norm(pixel_traces, axis=1, ord=2)
+        ind = pixel_traces_l2_norm > 0
+        pixel_traces[ind, :] = pixel_traces[ind, :] / pixel_traces_l2_norm[ind, None]
+        return pixel_traces, pixel_traces_l2_norm
+
+    def _crop(self, decoded_img, crop_size):
+        decoded_img[:, 0:crop_size] = 0
+        decoded_img[:, decoded_img.shape[1] - crop_size:] = 0
+        decoded_img[0:crop_size, :] = 0
+        decoded_img[decoded_img.shape[0] - crop_size:, :] = 0
+        return decoded_img
+
+    def _find_spots(self, decoded_img, area_threshold):
+        label_image = label(decoded_img, connectivity=2)
+        props = regionprops(label_image)
+
+        spots = []
+        for r in props:
+            if r.area >= area_threshold:
+                index = decoded_img[int(r.centroid[0]), int(r.centroid[1])]
+                if index > 0:
+                    data = {'barcode': self.codebook.barcode[index - 1],
+                            'x': r.centroid[0],
+                            'y': r.centroid[1],
+                            'area': r.area
+                            }
+                    spots.append(data)
+
+        spots_df = pd.DataFrame(spots)
+        spots_df['spot_id'] = range(len(spots_df))
+
+        return spots_df

--- a/starfish/spots/pixel.py
+++ b/starfish/spots/pixel.py
@@ -2,80 +2,30 @@ from __future__ import division
 
 import numpy as np
 import pandas as pd
-from skimage.filters import threshold_otsu
-import scipy.ndimage.measurements as spm
-from starfish.stats import label_to_regions
+
+from starfish.munge import gather
 
 
 class PixelSpotDetector:
-    def __init__(self, stack, blobs):
+    def __init__(self, stack):
         self.stack = stack
-        self.blobs = blobs
 
         self.num_objs = None
         self.spots_df = None
-        self.spots_df_viz = None
-        self.threshold = None
 
-    def detect(self):
-        self.spots_df_viz = self.to_viz_dataframe()
-        self.spots_df = self.to_encoder_dataframe()
+    def detect(self, bit_map_flag=False):
 
-    def to_encoder_dataframe(self):
-        """
-        Writes table of spot_id | hyb | ch | val
-        :param min_intensity: minimum intensity of pixel value to retain 
-        :return: spots_df 
-        """
+        sq = self.stack.squeeze(bit_map_flag=bit_map_flag)
+        num_bits = self.stack.squeeze_map.bit.max() + 1
 
-        def encode(row, squeezed_stack):
-            r = row[1]
-            sq = squeezed_stack[r.ind]
-            sqt = sq[self.threshold[:, 0], self.threshold[:, 1]]
-            val = sqt.ravel()
-            d = pd.DataFrame()
-            d['spot_id'] = range(self.num_objs)
-            d['val'] = val
-            d['hyb'] = r.hyb
-            d['ch'] = r.ch
-            return d
+        if self.stack.is_volume:
+            mat = np.reshape(sq.copy(), (sq.shape[0], sq.shape[1] * sq.shape[2] * sq.shape[3]))
+        else:
+            mat = np.reshape(sq.copy(), (sq.shape[0], sq.shape[1] * sq.shape[2]))
 
-        squeezed_stack = self.stack.squeeze()
-        squeeze_map = self.stack.squeeze_map
-        res = [encode(row, squeezed_stack) for row in squeeze_map.iterrows()]
-        self.spots_df = pd.concat(res)
+        res = pd.DataFrame(mat.T)
+        res['spot_id'] = range(len(res))
+        res = gather(res, 'ind', 'val', range(num_bits))
+        spots_df_tidy = pd.merge(res, self.stack.squeeze_map, on='ind', how='left')
 
-        return self.spots_df
-
-    def to_viz_dataframe(self):
-        """
-        Determines pixel locations worthy of decoding. Uses otsu thresholding to separate
-        signal from background. This decreases search space necessary for pixel based readout
-        :return: spots_df_viz: | spot_id | x | y | z | 
-        """
-
-        # determine threshold
-        t = threshold_otsu(self.blobs)
-        blobs_binary = self.blobs > t
-        ind = np.argwhere(blobs_binary)
-        self.threshold = ind
-
-        # construct spots_viz
-        self.num_objs = ind.shape[0]
-        df = pd.DataFrame()
-        df['spot_id'] = range(self.num_objs)
-        df['x'] = ind[:, 0]
-        df['y'] = ind[:, 1]
-
-        # assign groupings to spots (pixels)
-        labels, num_objs = spm.label(blobs_binary)
-        regions = label_to_regions(labels)
-        for grp_num, r in enumerate(regions):
-            cond_1 = df.x.isin(r.coordinates[:, 0])
-            cond_2 = df.y.isin(r.coordinates[:, 1])
-            cond = cond_1 & cond_2
-            df.loc[cond, 'spot_group'] = grp_num
-
-        self.spots_df_viz = df
-
-        return self.spots_df_viz
+        return spots_df_tidy


### PR DESCRIPTION
This PR implements a merfish decoder by:

1. Creating a simple pixel-based spot detector, which assigns each pixel to a spot_id in the standardized encoder table format. Technically, this is not necessary for the decoder, but does keep in line with our standard file format for other kinds of data.

2. Creating a MerfishDecoder class that takes as input the output of the pixel-based spot detector, the codebook, and some tuning parameters.

I verified that this can re-produce results from a collaborator with r = 0.99 for copy number comparison.