### PR TITLE
Prepare for enabling lint.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length=120
+ignore: E301, E302, E305, E401, F401

--- a/starfish/spots/gaussian.py
+++ b/starfish/spots/gaussian.py
@@ -52,15 +52,9 @@ class GaussianSpotDetector:
             row = row[1]
             subset = img[int(row.xmin):int(row.xmax), int(row.ymin):int(row.ymax)]
             if self.measurement_type == 'max':
-                try:
-                    res.append(subset.max())
-                except:
-                    res.append(np.NAN)
+                res.append(subset.max())
             else:
-                try:
-                    res.append(subset.mean())
-                except:
-                    res.append(np.NAN)
+                res.append(subset.mean())
         return res
 
     def _measure_stack(self):

--- a/starfish/starfish.py
+++ b/starfish/starfish.py
@@ -19,7 +19,6 @@ PROFILER_NOOP_ENVVAR = 'PROFILE_TEST'
 """If this environment variable is present, we create a no-op command for the purposes of testing the profiler."""
 
 
-
 @click.group()
 @click.option("--profile", is_flag=True)
 @click.pass_context


### PR DESCRIPTION
1. Set column limit to 120.
2. Remove some generic try-catch'es. (I checked numpy's `max` and `mean` functions, and it seems to handle NaN in input correctly.  It does, however, barf on a 2D array that's incorrectly set up, e.g., a row/column that's a scalar instead of an vector).