### PR TITLE
use the standard module __main__ to drive command line interpreter usage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,6 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=install_requires,
     entry_points={
-        'console_scripts': "starfish=starfish.starfish:starfish"
+        'console_scripts': "starfish=starfish.__main__"
     }
 )

--- a/starfish/__main__.py
+++ b/starfish/__main__.py
@@ -1,0 +1,3 @@
+from .starfish import starfish
+
+starfish()

--- a/starfish/starfish.py
+++ b/starfish/starfish.py
@@ -258,6 +258,3 @@ if PROFILER_NOOP_ENVVAR in os.environ:
     @starfish.command()
     def noop():
         pass
-
-if __name__ == "__main__":
-    starfish()

--- a/tests/test_iss_data.py
+++ b/tests/test_iss_data.py
@@ -89,7 +89,7 @@ class TestWithIssData(unittest.TestCase):
                         "coverage", "run",
                         "-p",
                         "--source", "starfish",
-                        "-m", "starfish.starfish",
+                        "-m", "starfish",
                     ]
                     coverage_cmdline.extend(cmdline[1:])
                     cmdline = coverage_cmdline

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -25,7 +25,7 @@ class TestProfiler(unittest.TestCase):
                 "coverage", "run",
                 "-p",
                 "--source", "starfish",
-                "-m", "starfish.starfish",
+                "-m", "starfish",
             ]
             coverage_cmdline.extend(cmdline[1:])
             cmdline = coverage_cmdline
@@ -47,7 +47,7 @@ class TestProfiler(unittest.TestCase):
                 "coverage", "run",
                 "-p",
                 "--source", "starfish",
-                "-m", "starfish.starfish",
+                "-m", "starfish",
             ]
             coverage_cmdline.extend(cmdline[1:])
             cmdline = coverage_cmdline


### PR DESCRIPTION
This allows us to convert starfish into a proper package without harmless yet scary looking messages.