### PR TITLE
[easy] add quick sanity test to ensure that the pipeline actually ran.

### DIFF
--- a/tests/test_iss_data.py
+++ b/tests/test_iss_data.py
@@ -1,3 +1,4 @@
+import collections
 import os
 import shutil
 import subprocess
@@ -94,5 +95,16 @@ class TestWithIssData(unittest.TestCase):
                     cmdline = coverage_cmdline
                 with clock.timeit(callback):
                     subprocess.check_call(cmdline)
+            with open(os.path.join(tempdir, "results", "decoder_table.csv")) as fh:
+                lines = fh.readlines()
+                counts = collections.defaultdict(lambda: 0)
+                for line in lines[1:]:
+                    line_barcode = line.split(",")[0]
+                    counts[line_barcode] += 1
+
+                tuples = [(count, barcode) for barcode, count in counts.items()]
+                tuples.sort(reverse=True)
+                self.assertEqual("AAGC", tuples[0][1])
+                self.assertEqual("AGGC", tuples[1][1])
         finally:
             shutil.rmtree(tempdir)


### PR DESCRIPTION
Currently, we just verify that starfish runs and doesn't crash.  This adds a quick sanity test to ensure that _some_ result is generated and that the result seems reasonable.