### PR TITLE
[imagestack] Normalize file format field.

### DIFF
--- a/examples/get_iss_data.py
+++ b/examples/get_iss_data.py
@@ -56,11 +56,11 @@ def load_and_write_data(input_dir, output_dir):
 
     dapi_fname = '{}_{}.tiff'.format(prefix, 'dapi')
     imsave(output_dir + dapi_fname, dapi)
-    res['aux'].append({'type': 'dapi', 'file': dapi_fname})
+    res['aux'].append({'type': 'dapi', 'file': dapi_fname, 'format': "TIFF"})
 
     dots_fname = '{}_{}.tiff'.format(prefix, 'dots')
     imsave(output_dir + dots_fname, dots)
-    res['aux'].append({'type': 'dots', 'file': dots_fname})
+    res['aux'].append({'type': 'dots', 'file': dots_fname, 'format': "TIFF"})
 
     if len(img.shape) == 2:
         is_volume = False
@@ -73,7 +73,7 @@ def load_and_write_data(input_dir, output_dir):
     res['metadata']['num_chs'] = 4
     res['metadata']['shape'] = img.shape
     res['metadata']['is_volume'] = is_volume
-    res['metadata']['format'] = 'tiff'
+    res['metadata']['format'] = "TIFF"
 
     return res
 

--- a/starfish/io.py
+++ b/starfish/io.py
@@ -62,7 +62,7 @@ class Stack:
 
         self.format = d['format']
 
-        if self.format == 'tiff':
+        if self.format == 'TIFF':
             self.read_fn = io.imread
         else:
             self.read_fn = np.load
@@ -93,7 +93,7 @@ class Stack:
 
     def _write_metadata(self, dir_name):
         new_org = self.org
-        new_org['metadata']['format'] = 'npy'
+        new_org['metadata']['format'] = 'NPY'
 
         def format(d):
             d['file'] = self._swap_ext(d['file']) + '.npy'
@@ -121,7 +121,7 @@ class Stack:
             self.write_fn(os.path.join(dir_name, fname), self.aux_dict[typ])
 
     def _swap_ext(self, fname):
-        if self.format == 'tiff':
+        if self.format == 'TIFF':
             fname = fname.replace('.tiff', '')
         else:
             fname = fname.replace('.npy', '')


### PR DESCRIPTION
1. Always use it in upper case (in preparation for conversion to an Enum)
2. Always have it present, for aux as well.