### PR TITLE
[imagestack] Separate the notion of a starfish input set with an image stack

### DIFF
--- a/starfish/image/__init__.py
+++ b/starfish/image/__init__.py
@@ -1,0 +1,2 @@
+from ._base import ImageBase, ImageFormat
+from ._stack import ImageStack

--- a/starfish/image/_base.py
+++ b/starfish/image/_base.py
@@ -1,0 +1,42 @@
+import enum
+
+import numpy
+import skimage.io
+
+
+class ImageBase(object):
+    @property
+    def numpy_array(self):
+        """Retrieves the image data as a numpy array."""
+        raise NotImplementedError()
+
+    @property
+    def shape(self):
+        """Retrieves the shape of the image data."""
+        raise NotImplementedError()
+
+    def write(self, filepath):
+        """
+        Writes the image out to disk.
+
+        Args:
+            filepath: The path of the file to write the image to.
+        """
+        raise NotImplementedError()
+
+
+class ImageFormat(enum.Enum):
+    TIFF = (skimage.io.imread, "tiff")
+    NUMPY = (numpy.load, "npy")
+
+    def __init__(self, reader_func, file_ext):
+        self._reader_func = reader_func
+        self._file_ext = file_ext
+
+    @property
+    def reader_func(self):
+        return self._reader_func
+
+    @property
+    def file_ext(self):
+        return self._file_ext

--- a/starfish/image/_stack.py
+++ b/starfish/image/_stack.py
@@ -1,0 +1,103 @@
+import json
+import os
+
+import numpy
+
+from ._base import ImageBase, ImageFormat
+
+
+class ImageStack(ImageBase):
+    def __init__(self, data, tile_format, num_hybs, num_chs, tile_shape):
+        self._data = data
+        self._tile_format = tile_format
+
+        # shape data
+        self._num_hybs = num_hybs
+        self._num_chs = num_chs
+        self._tile_shape = tile_shape
+
+    @classmethod
+    def from_org_json(cls, org_json_path):
+        with open(org_json_path, 'r') as in_file:
+            org_json = json.load(in_file)
+        metadata_dict = org_json['metadata']
+        num_hybs = metadata_dict['num_hybs']
+        num_chs = metadata_dict['num_chs']
+        tile_shape = tuple(metadata_dict['shape'])
+
+        data = numpy.zeros((num_hybs, num_chs) + tile_shape)
+        tile_format = ImageFormat[metadata_dict['format']]
+
+        data_dicts = org_json['data']
+        base_path = os.path.dirname(org_json_path)
+
+        for data_dict in data_dicts:
+            h = data_dict['hyb']
+            c = data_dict['ch']
+            fname = data_dict['file']
+            im = tile_format.reader_func(os.path.join(base_path, fname))
+            data[h, c, :] = im
+
+        return ImageStack(data, tile_format, num_hybs, num_chs, tile_shape)
+
+    @property
+    def numpy_array(self):
+        return self._data
+
+    @property
+    def shape(self):
+        if self._data is None:
+            return None
+        else:
+            return self._data.shape
+
+    @property
+    def num_hybs(self):
+        return self._num_hybs
+
+    @property
+    def num_chs(self):
+        return self._num_chs
+
+    @property
+    def tile_shape(self):
+        return self._tile_shape
+
+    def write(self, filepath, tile_filename_formatter=None):
+        prefix = os.path.splitext(os.path.basename(filepath))[0]
+        basepath = os.path.dirname(filepath)
+        if tile_filename_formatter is None:
+            def tile_filename_formatter(x, y, hyb, ch):
+                return "{}-x_{}-y_{}-h_{}-c_{}".format(prefix, x, y, hyb, ch)
+
+        data = list()
+
+        for hyb in range(self._num_hybs):
+            for ch in range(self._num_chs):
+                tile_filename = tile_filename_formatter(0, 0, hyb, ch)
+                tile = {
+                    'hyb': hyb,
+                    'ch': ch,
+                    'file': "{}.{}".format(tile_filename, ImageFormat.NUMPY.file_ext),
+                }
+                numpy.save(os.path.join(basepath, tile_filename), self._data[hyb, ch, :])
+                data.append(tile)
+
+        return data
+
+    def max_proj(self, dim):
+        valid_dims = ['hyb', 'ch', 'z']
+        if dim not in valid_dims:
+            msg = "Dimension: {} not supported. Expecting one of: {}".format(dim, valid_dims)
+            raise ValueError(msg)
+
+        if dim == 'hyb':
+            res = numpy.max(self._data, axis=0)
+        elif dim == 'ch':
+            res = numpy.max(self._data, axis=1)
+        elif dim == 'z' and len(self._tile_shape) > 2:
+            res = numpy.max(self._data, axis=4)
+        else:
+            res = self.data
+
+        return res

--- a/starfish/io.py
+++ b/starfish/io.py
@@ -3,80 +3,32 @@ import os
 
 import numpy as np
 import pandas as pd
-from skimage import io
 
+from .image import ImageFormat, ImageStack
 from .munge import list_to_stack
 
 
 class Stack:
     def __init__(self):
-
         # data organization
         self.org = None
         self.path = None
-        self.format = None
-
-        # numpy array (num_hybs, num_chans, x, y, z)
-        self.data = None
+        self.image = None
 
         # auxilary images
         self.aux_dict = dict()
-
-        # shape data
-        self.num_hybs = None
-        self.num_chs = None
-        self.im_shape = None
-        self.is_volume = None
-        self.squeeze_map = None
 
         # readers and writers
         self.read_fn = None  # set by self._read_metadata
         self.write_fn = np.save  # asserted for now
 
-    @property
-    def shape(self):
-        if self.data is None:
-            return None
-        else:
-            return self.data.shape
-
     def read(self, in_json):
+        # TODO: (ttung) remove this hackery
+        self.path = os.path.dirname(in_json)
         with open(in_json, 'r') as in_file:
             self.org = json.load(in_file)
-
-        self.path = os.path.dirname(os.path.abspath(in_json)) + '/'
-        self._read_metadata()
-        self._read_stack()
+        self.image = ImageStack.from_org_json(in_json)
         self._read_aux()
-
-    def _read_metadata(self):
-        d = self.org['metadata']
-        self.num_hybs = d['num_hybs']
-        self.num_chs = d['num_chs']
-        self.im_shape = tuple(d['shape'])
-
-        self.is_volume = d['is_volume']
-        if not self.is_volume:
-            self.data = np.zeros((self.num_hybs, self.num_chs, self.im_shape[0], self.im_shape[1]))
-        else:
-            self.data = np.zeros((self.num_hybs, self.num_chs, self.im_shape[0], self.im_shape[1], self.im_shape[2]))
-
-        self.format = d['format']
-
-        if self.format == 'TIFF':
-            self.read_fn = io.imread
-        else:
-            self.read_fn = np.load
-
-    def _read_stack(self):
-        data_dicts = self.org['data']
-
-        for d in data_dicts:
-            h = d['hyb']
-            c = d['ch']
-            fname = d['file']
-            im = self.read_fn(os.path.join(self.path, fname))
-            self.data[h, c, :] = im
 
     def _read_aux(self):
         data_dicts = self.org['aux']
@@ -84,76 +36,56 @@ class Stack:
         for d in data_dicts:
             typ = d['type']
             fname = d['file']
-            self.aux_dict[typ] = self.read_fn(os.path.join(self.path, fname))
+            img_format = ImageFormat[d['format']]
+            self.aux_dict[typ] = img_format.reader_func(os.path.join(self.path, fname))
 
     # TODO should this thing write npy?
     def write(self, dir_name):
-        self._write_metadata(dir_name)
         self._write_stack(dir_name)
         self._write_aux(dir_name)
+        self._write_metadata(dir_name)
 
     def _write_metadata(self, dir_name):
-        self.org['metadata']['format'] = 'NPY'
-
-        def format(d):
-            d['file'] = "{}.{}".format(os.path.splitext(d['file'])[0], 'npy')
-            return d
-
-        self.org['data'] = [format(d) for d in self.org['data']]
-        self.org['aux'] = [format(d) for d in self.org['aux']]
+        self.org['metadata']['format'] = ImageFormat.NUMPY.name
 
         with open(os.path.join(dir_name, 'org.json'), 'w') as outfile:
             json.dump(self.org, outfile, indent=4)
 
     def _write_stack(self, dir_name):
-        for d in self.org['data']:
-            h = d['hyb']
-            c = d['ch']
-            fname = d['file']
-            self.write_fn(os.path.join(dir_name, fname), self.data[h, c, :])
+        self.org['data'] = self.image.write(os.path.join(dir_name, "org.json"))
 
     def _write_aux(self, dir_name):
         for d in self.org['aux']:
             typ = d['type']
-            fname = d['file']
+            fname = os.path.splitext(d['file'])[0]
+            d['file'] = "{}.{}".format(fname, ImageFormat.NUMPY.file_ext)
+            d['format'] = ImageFormat.NUMPY.name
             self.write_fn(os.path.join(dir_name, fname), self.aux_dict[typ])
 
     def set_stack(self, new_stack):
-        if new_stack.shape != self.shape:
-            msg = "Shape mismatch. Current data shape: {}, new data shape: {}".format(self.shape, new_stack.shape)
+        if new_stack.shape != self.image.shape:
+            msg = "Shape mismatch. Current data shape: {}, new data shape: {}".format(
+                self.image.shape, new_stack.shape)
             raise AttributeError(msg)
-        self.data = new_stack
+        self.image = ImageStack(
+            new_stack, ImageFormat.NUMPY.name, self.image.num_hybs, self.image.num_chs, self.image.tile_shape)
 
     def set_aux(self, key, img):
         if key in self.aux_dict:
-            old_stack = self.aux_dict[key]
-            if old_stack.shape != img.shape:
-                msg = "Shape mismatch. Current data shape: {}, new data shape: {}".format(old_stack.shape,
-                                                                                          img.shape)
+            old_img = self.aux_dict[key]
+            if old_img.shape != img.shape:
+                msg = "Shape mismatch. Current data shape: {}, new data shape: {}".format(
+                    old_img.shape, img.shape)
                 raise AttributeError(msg)
         else:
-            self.org['aux'].append({'file': key, 'type': key})
+            self.org['aux'].append({'file': key, 'type': key, 'format': ImageFormat.NUMPY.name})
         self.aux_dict[key] = img
 
     def max_proj(self, dim):
-        valid_dims = ['hyb', 'ch', 'z']
-        if dim not in valid_dims:
-            msg = "Dimension: {} not supported. Expecting one of: {}".format(dim, valid_dims)
-            raise ValueError(msg)
-
-        if dim == 'hyb':
-            res = np.max(self.data, axis=0)
-        elif dim == 'ch':
-            res = np.max(self.data, axis=1)
-        elif dim == 'z' and self.is_volume:
-            res = np.max(self.data, axis=4)
-        else:
-            res = self.data
-
-        return res
+        return self.image.max_proj(dim)
 
     def squeeze(self, bit_map_flag=False):
-        new_shape = ((self.num_hybs * self.num_chs),) + self.im_shape
+        new_shape = ((self.image.num_hybs * self.image.num_chs),) + self.image.tile_shape
         new_data = np.zeros(new_shape)
 
         # TODO this can all probably be done smartly with np.reshape instead of a double for loop
@@ -162,9 +94,9 @@ class Stack:
         hybs = []
         chs = []
 
-        for h in range(self.num_hybs):
-            for c in range(self.num_chs):
-                new_data[ind, :] = self.data[h, c, :]
+        for h in range(self.image.num_hybs):
+            for c in range(self.image.num_chs):
+                new_data[ind, :] = self.image.numpy_array[h, c, :]
                 inds.append(ind)
                 hybs.append(h)
                 chs.append(c)
@@ -183,13 +115,13 @@ class Stack:
         if type(stack) is list:
             stack = list_to_stack(stack)
 
-        new_shape = (self.num_hybs, self.num_chs) + self.im_shape
+        new_shape = (self.image.num_hybs, self.image.num_chs) + self.image.tile_shape
         res = np.zeros(new_shape)
 
         # TODO this can probably done smartly without a double for loop
         ind = 0
-        for h in range(self.num_hybs):
-            for c in range(self.num_chs):
+        for h in range(self.image.num_hybs):
+            for c in range(self.image.num_chs):
                 res[h, c, :] = stack[ind, :]
                 ind += 1
 

--- a/starfish/registration/_fourier_shift.py
+++ b/starfish/registration/_fourier_shift.py
@@ -19,16 +19,16 @@ class FourierShiftRegistration(RegistrationAlgorithmBase):
         import numpy as np
 
         mp = stack.max_proj('ch')
-        res = np.zeros(stack.shape)
+        res = np.zeros(stack.image.shape)
 
-        for h in range(stack.num_hybs):
+        for h in range(stack.image.num_hybs):
             # compute shift between maximum projection (across channels) and dots, for each hyb round
             shift, error = compute_shift(mp[h, :, :], stack.aux_dict['dots'], self.upsampling)
             print("For hyb: {}, Shift: {}, Error: {}".format(h, shift, error))
 
-            for c in range(stack.num_chs):
+            for c in range(stack.image.num_chs):
                 # apply shift to all channels and hyb rounds
-                res[h, c, :] = shift_im(stack.data[h, c, :], shift)
+                res[h, c, :] = shift_im(stack.image.numpy_array[h, c, :], shift)
 
         stack.set_stack(res)
 


### PR DESCRIPTION
Image stacks are a logically different concept than a starfish input set. This PR attempts to separate the two concepts in the *code* in preparation for separating the manifest files that describe them.  With this change, we continue to source image stack data from org.json, but in code, it's a component within the input set.

In a future PR, the image stack data will be extracted to a separate file.
