### PR TITLE
Convert in_json and out_dir to required parameters

### DIFF
--- a/starfish/registration/__init__.py
+++ b/starfish/registration/__init__.py
@@ -12,8 +12,8 @@ class Registration(object):
     def add_to_parser(cls, subparsers):
         """Adds the registration component to the CLI argument parser."""
         register_group = subparsers.add_parser("register")
-        register_group.add_argument("in_json", type=FsExistsType())
-        register_group.add_argument("out_dir", type=FsExistsType())
+        register_group.add_argument("-i", "--input", type=FsExistsType(), required=True)
+        register_group.add_argument("-o", "--output", type=FsExistsType(), required=True)
         register_group.set_defaults(starfish_command=Registration._cli)
         registration_subparsers = register_group.add_subparsers(dest="registration_algorithm_class")
 
@@ -44,11 +44,11 @@ class Registration(object):
 
         print('Registering ...')
         s = Stack()
-        s.read(args.in_json)
+        s.read(args.input)
 
         instance.register(s)
 
-        s.write(args.out_dir)
+        s.write(args.output)
 
     @classmethod
     def _ensure_algorithms_setup(cls):

--- a/tests/test_iss_data.py
+++ b/tests/test_iss_data.py
@@ -33,8 +33,8 @@ class TestWithIssData(unittest.TestCase):
         ],
         [
             "starfish", "register",
-            lambda tempdir, *args, **kwargs: os.path.join(tempdir, "formatted", "org.json"),
-            lambda tempdir, *args, **kwargs: os.path.join(tempdir, "registered"),
+            "--input", lambda tempdir, *args, **kwargs: os.path.join(tempdir, "formatted", "org.json"),
+            "--output", lambda tempdir, *args, **kwargs: os.path.join(tempdir, "registered"),
             "fourier_shift",
             "--u", "1000",
         ],


### PR DESCRIPTION
help looks like this now:

```
[czipa1osx186 (.venv)]:~/microscopy/starfish:master> starfish register fourier_shift --help
usage: starfish register fourier_shift [-h] [--u U]

optional arguments:
  -h, --help  show this help message and exit
  --u U       Amount of up-sampling
h[czipa1osx186 (.venv)]:~/microscopy/starfish:master>
```

Fixes #40