### PR TITLE
Refactor how the individual algorithms are set up.

### DIFF
--- a/starfish/registration/__init__.py
+++ b/starfish/registration/__init__.py
@@ -1,4 +1,5 @@
 import collections
+import functools
 
 from ..util.argparse import FsExistsType
 from . import _base
@@ -17,16 +18,16 @@ class Registration(object):
         register_group.set_defaults(starfish_command=Registration._cli)
         registration_subparsers = register_group.add_subparsers(dest="registration_algorithm_class")
 
-        cls._ensure_algorithms_setup()
         for algorithm_cls in cls.algorithm_to_class_map.values():
-            algorithm_cls.add_to_parser(registration_subparsers)
+            group_parser = registration_subparsers.add_parser(algorithm_cls.get_algorithm_name())
+            group_parser.set_defaults(registration_algorithm_class=algorithm_cls)
+            algorithm_cls.add_arguments(group_parser)
 
         cls.register_group = register_group
 
     @classmethod
     def run(cls, algorithm_name, stack, *args, **kwargs):
         """Runs the registration component using the algorithm name, stack, and arguments for the specific algorithm."""
-        cls._ensure_algorithms_setup()
         algorithm_cls = cls.algorithm_to_class_map[algorithm_name]
         instance = algorithm_cls(*args, **kwargs)
         return instance.register(stack)
@@ -61,3 +62,6 @@ class Registration(object):
             queue.extend(algorithm_cls.__subclasses__())
 
             cls.algorithm_to_class_map[algorithm_cls.__name__] = algorithm_cls
+
+
+Registration._ensure_algorithms_setup()

--- a/starfish/registration/_base.py
+++ b/starfish/registration/_base.py
@@ -10,8 +10,16 @@ class RegistrationAlgorithmBase(object):
         raise NotImplementedError()
 
     @classmethod
-    def add_to_parser(cls, subparsers):
-        """Adds the registration algorithm to the CLI argument parser."""
+    def get_algorithm_name(cls):
+        """
+        Returns the name of the algorithm.  This should be a valid python identifier, i.e.,
+        https://docs.python.org/3/reference/lexical_analysis.html#identifiers
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    def add_arguments(cls, parser):
+        """Adds the arguments for the algorithm."""
         raise NotImplementedError()
 
     def register(self, stack):

--- a/starfish/registration/_fourier_shift.py
+++ b/starfish/registration/_fourier_shift.py
@@ -14,10 +14,12 @@ class FourierShiftRegistration(RegistrationAlgorithmBase):
         return FourierShiftRegistration(args.u)
 
     @classmethod
-    def add_to_parser(cls, subparsers):
-        fourier_shift_group = subparsers.add_parser("fourier_shift")
-        fourier_shift_group.add_argument("--u", default=1, type=int, help="Amount of up-sampling")
-        fourier_shift_group.set_defaults(registration_algorithm_class=FourierShiftRegistration)
+    def get_algorithm_name(cls):
+        return "fourier_shift"
+
+    @classmethod
+    def add_arguments(cls, group_parser):
+        group_parser.add_argument("--u", default=1, type=int, help="Amount of up-sampling")
 
     def register(self, stack):
         import numpy as np


### PR DESCRIPTION
1. The algorithms are now required to implement two methods.
  a. `get_algorithm_name()`, which returns the name of the algorithm.
  b. `add_arguments(parser)`, which adds the algorithm's arguments to the parser.
2. The top-level pipeline stage (e.g., Registration) is now responsible for setting up the parser.  This reduces boilerplate code.
3. Explicitly calls `_ensure_algorithms_setup()`.