### PR TITLE
Convert .ipynb to .py and compare for validation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,5 @@ $(test_srcs): %.py :
 	coverage run -p --source=starfish -m unittest $(subst /,.,$*)
 
 .PHONY : $(test_srcs)
+
+include notebooks/subdir.mk

--- a/REQUIREMENTS-DEV.txt
+++ b/REQUIREMENTS-DEV.txt
@@ -1,3 +1,4 @@
 coverage
+nbencdec
 flake8
 -r REQUIREMENTS.txt

--- a/notebooks/subdir.mk
+++ b/notebooks/subdir.mk
@@ -1,0 +1,10 @@
+ipynb_files := $(wildcard notebooks/*.ipynb)
+ipynb_validate_targets := $(addprefix validate__, $(ipynb_files))
+
+test: $(ipynb_validate_targets)
+validate_notebooks: $(ipynb_validate_targets)
+
+$(ipynb_validate_targets): TEMPFILE := $(shell mktemp)
+$(ipynb_validate_targets): validate__%.ipynb :
+	nbencdec encode $*.ipynb $(TEMPFILE)
+	diff -q $*.py $(TEMPFILE)


### PR DESCRIPTION
Add makefile rules to automatically validate all notebooks in notebooks/*.  Note that this will _fail_ travis test builds because `notebooks/Starfish_simulation.py` does not exist.
